### PR TITLE
feat: Added `FlipableFlashcard` composable with swipe gesture support.

### DIFF
--- a/feature/main/ui/src/main/kotlin/com/epiclabs/thinktok/main/ui/main/FlipableFlashcard.kt
+++ b/feature/main/ui/src/main/kotlin/com/epiclabs/thinktok/main/ui/main/FlipableFlashcard.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
@@ -55,7 +54,6 @@ fun FlipableFlashcard(
         Box(
             modifier =
                 Modifier
-                    .width(300.dp)
                     .pointerInput(Unit) {
                         detectHorizontalDragGestures { change, dragAmount ->
                             change.consume()

--- a/feature/main/ui/src/main/kotlin/com/epiclabs/thinktok/main/ui/main/FlipableFlashcard.kt
+++ b/feature/main/ui/src/main/kotlin/com/epiclabs/thinktok/main/ui/main/FlipableFlashcard.kt
@@ -1,0 +1,148 @@
+package com.epiclabs.thinktok.main.ui.main
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlin.math.absoluteValue
+
+@Composable
+fun FlipableFlashcard(
+    front: @Composable () -> Unit,
+    back: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isFlipped by remember { mutableStateOf(false) }
+    var rotationY by remember { mutableStateOf(0f) }
+
+    val animatedRotationY by animateFloatAsState(
+        targetValue = rotationY,
+        animationSpec = tween(durationMillis = 500, easing = FastOutSlowInEasing),
+        label = "rotationY",
+    )
+    val density = LocalDensity.current.density
+
+    BoxWithConstraints(
+        modifier = modifier.padding(16.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .width(300.dp)
+                    .pointerInput(Unit) {
+                        detectHorizontalDragGestures { change, dragAmount ->
+                            change.consume()
+                            if (dragAmount.absoluteValue > 10) {
+                                if (!isFlipped && dragAmount > 0) {
+                                    // Swipe right to flip to back
+                                    rotationY = 180f
+                                    isFlipped = true
+                                } else if (isFlipped && dragAmount < 0) {
+                                    // Swipe left to flip to front
+                                    rotationY = 0f
+                                    isFlipped = false
+                                }
+                            }
+                        }
+                    }
+                    .graphicsLayer {
+                        this.rotationY = animatedRotationY
+                        cameraDistance = 8 * density
+                    },
+        ) {
+            if (animatedRotationY <= 90f) {
+                // Front of the card
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(16.dp),
+                ) {
+                    front()
+                }
+            } else {
+                // Back of the card
+                Card(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .graphicsLayer {
+                                this.rotationY = 180f
+                            },
+                    shape = RoundedCornerShape(16.dp),
+                ) {
+                    back()
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FlipableFlashcardPreview() {
+    val word = "Example Word"
+    val translation = "Example Translation"
+    FlipableFlashcard(
+        modifier =
+            Modifier
+                .fillMaxSize(),
+        front = {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(color = MaterialTheme.colorScheme.primaryContainer),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = word,
+                    style = MaterialTheme.typography.headlineMedium,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        },
+        back = {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = translation,
+                    style = MaterialTheme.typography.headlineMedium,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        },
+    )
+}

--- a/feature/main/ui/src/main/kotlin/com/epiclabs/thinktok/main/ui/main/FlipableFlashcard.kt
+++ b/feature/main/ui/src/main/kotlin/com/epiclabs/thinktok/main/ui/main/FlipableFlashcard.kt
@@ -26,13 +26,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlin.math.absoluteValue
 
+const val FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG = "FlipableFlashcardFrontSide"
+const val FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG = "FlipableFlashcardBackSide"
+
 @Composable
-fun FlipableFlashcard(
+internal fun FlipableFlashcard(
     front: @Composable () -> Unit,
     back: @Composable () -> Unit,
     modifier: Modifier = Modifier,
@@ -78,7 +82,10 @@ fun FlipableFlashcard(
             if (animatedRotationY <= 90f) {
                 // Front of the card
                 Card(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier =
+                        Modifier
+                            .testTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG)
+                            .fillMaxWidth(),
                     shape = RoundedCornerShape(16.dp),
                 ) {
                     front()
@@ -88,6 +95,7 @@ fun FlipableFlashcard(
                 Card(
                     modifier =
                         Modifier
+                            .testTag(FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG)
                             .fillMaxWidth()
                             .graphicsLayer {
                                 this.rotationY = 180f

--- a/feature/main/ui/src/main/kotlin/com/epiclabs/thinktok/main/ui/main/FlipableFlashcard.kt
+++ b/feature/main/ui/src/main/kotlin/com/epiclabs/thinktok/main/ui/main/FlipableFlashcard.kt
@@ -32,11 +32,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlin.math.absoluteValue
 
-const val FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG = "FlipableFlashcardFrontSide"
-const val FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG = "FlipableFlashcardBackSide"
+const val FLIPPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG = "FlippableFlashcardFrontSide"
+const val FLIPPABLE_FLASHCARD_BACK_SIDE_TEST_TAG = "FlippableFlashcardBackSide"
 
 @Composable
-internal fun FlipableFlashcard(
+internal fun FlippableFlashcard(
     front: @Composable () -> Unit,
     back: @Composable () -> Unit,
     modifier: Modifier = Modifier,
@@ -84,7 +84,7 @@ internal fun FlipableFlashcard(
                 Card(
                     modifier =
                         Modifier
-                            .testTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG)
+                            .testTag(FLIPPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG)
                             .fillMaxWidth(),
                     shape = RoundedCornerShape(16.dp),
                 ) {
@@ -95,7 +95,7 @@ internal fun FlipableFlashcard(
                 Card(
                     modifier =
                         Modifier
-                            .testTag(FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG)
+                            .testTag(FLIPPABLE_FLASHCARD_BACK_SIDE_TEST_TAG)
                             .fillMaxWidth()
                             .graphicsLayer {
                                 this.rotationY = 180f
@@ -111,10 +111,10 @@ internal fun FlipableFlashcard(
 
 @Preview(showBackground = true)
 @Composable
-private fun FlipableFlashcardPreview() {
+private fun FlippableFlashcardPreview() {
     val word = "Example Word"
     val translation = "Example Translation"
-    FlipableFlashcard(
+    FlippableFlashcard(
         modifier =
             Modifier
                 .fillMaxSize(),

--- a/feature/main/ui/src/test/java/com/epiclabs/thinktok/main/ui/languageselection/FlipableFlashcardTest.kt
+++ b/feature/main/ui/src/test/java/com/epiclabs/thinktok/main/ui/languageselection/FlipableFlashcardTest.kt
@@ -1,0 +1,112 @@
+package com.epiclabs.thinktok.main.ui.languageselection
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.swipeRight
+import com.epiclabs.thinktok.main.ui.main.FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG
+import com.epiclabs.thinktok.main.ui.main.FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG
+import com.epiclabs.thinktok.main.ui.main.FlipableFlashcard
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FlipableFlashcardTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val word = "Front"
+    private val translation = "Back"
+
+    @Test
+    fun `Given flipableFlashcard When initialState Then check word is displayed`() {
+        composeTestRule.setContent {
+            FlipableFlashcard(
+                front = { Text(text = word) },
+                back = { Text(text = translation) },
+            )
+        }
+        // Check if initially the word is displayed but the translation is not.
+        composeTestRule.onNode(hasText(text = word)).assertIsDisplayed()
+        composeTestRule.onNode(hasText(text = translation)).assertIsNotDisplayed()
+    }
+
+    // fun testSwipeRight_translationIsDisplayed() {
+    @Test
+    fun `Given flipableFlashcard When swipe right Then check translation is displayed`() {
+        composeTestRule.setContent {
+            FlipableFlashcard(
+                front = { Text(text = word) },
+                back = { Text(text = translation) },
+            )
+        }
+        // Flip the card with a swipe right gesture
+        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).performTouchInput { swipeRight() }
+
+        // Check if the translation is displayed after swiping to the right.
+        composeTestRule.onNode(hasText(text = translation)).assertIsDisplayed()
+
+        // Verify that the word does not appear after swiping to the right.
+        composeTestRule.onNode(hasText(text = word)).assertIsNotDisplayed()
+    }
+
+    @Test
+    fun `Given flipableFlashcard When initialState Then check front side is visible`() {
+        composeTestRule.setContent {
+            FlipableFlashcard(
+                front = { Text(text = word) },
+                back = { Text(text = translation) },
+            )
+        }
+        // Check if the front side is visible
+        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).assertExists()
+
+        // Check if the back side is not visible
+        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun `Given flipableFlashcard When swipe right Then check back side is visible`() {
+        composeTestRule.setContent {
+            FlipableFlashcard(
+                front = { Text(text = word) },
+                back = { Text(text = translation) },
+            )
+        }
+
+        // Flip the card with a swipe right gesture
+        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).performTouchInput { swipeRight() }
+        // Check if the back side of the flashcard is visible
+        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG).assertExists()
+        // Check if the front side of the flashcard is not visible
+        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun `Given flipableFlashcard When swipe right and left Then check front side is visible`() {
+        composeTestRule.setContent {
+            FlipableFlashcard(
+                front = { Text(text = word) },
+                back = { Text(text = translation) },
+            )
+        }
+
+        // Flip the card with a swipe right gesture
+        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).performTouchInput { swipeRight() }
+
+        // Flip the card with a swipe to left gesture to bring it back to the initial state
+        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG).performTouchInput { swipeLeft() }
+
+        // Check if the front side of the flashcard is visible
+        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).assertExists()
+        // Check if the back side of the flashcard is not visible
+        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG).assertDoesNotExist()
+    }
+}

--- a/feature/main/ui/src/test/java/com/epiclabs/thinktok/main/ui/languageselection/FlippableFlashcardTest.kt
+++ b/feature/main/ui/src/test/java/com/epiclabs/thinktok/main/ui/languageselection/FlippableFlashcardTest.kt
@@ -9,16 +9,16 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.swipeRight
-import com.epiclabs.thinktok.main.ui.main.FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG
-import com.epiclabs.thinktok.main.ui.main.FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG
-import com.epiclabs.thinktok.main.ui.main.FlipableFlashcard
+import com.epiclabs.thinktok.main.ui.main.FLIPPABLE_FLASHCARD_BACK_SIDE_TEST_TAG
+import com.epiclabs.thinktok.main.ui.main.FLIPPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG
+import com.epiclabs.thinktok.main.ui.main.FlippableFlashcard
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class FlipableFlashcardTest {
+class FlippableFlashcardTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
@@ -26,9 +26,9 @@ class FlipableFlashcardTest {
     private val translation = "Back"
 
     @Test
-    fun `Given flipableFlashcard When initialState Then check word is displayed`() {
+    fun `Given flippableFlashcard When initialState Then check word is displayed`() {
         composeTestRule.setContent {
-            FlipableFlashcard(
+            FlippableFlashcard(
                 front = { Text(text = word) },
                 back = { Text(text = translation) },
             )
@@ -40,15 +40,15 @@ class FlipableFlashcardTest {
 
     // fun testSwipeRight_translationIsDisplayed() {
     @Test
-    fun `Given flipableFlashcard When swipe right Then check translation is displayed`() {
+    fun `Given flippableFlashcard When swipe right Then check translation is displayed`() {
         composeTestRule.setContent {
-            FlipableFlashcard(
+            FlippableFlashcard(
                 front = { Text(text = word) },
                 back = { Text(text = translation) },
             )
         }
         // Flip the card with a swipe right gesture
-        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).performTouchInput { swipeRight() }
+        composeTestRule.onNodeWithTag(FLIPPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).performTouchInput { swipeRight() }
 
         // Check if the translation is displayed after swiping to the right.
         composeTestRule.onNode(hasText(text = translation)).assertIsDisplayed()
@@ -58,55 +58,55 @@ class FlipableFlashcardTest {
     }
 
     @Test
-    fun `Given flipableFlashcard When initialState Then check front side is visible`() {
+    fun `Given flippableFlashcard When initialState Then check front side is visible`() {
         composeTestRule.setContent {
-            FlipableFlashcard(
+            FlippableFlashcard(
                 front = { Text(text = word) },
                 back = { Text(text = translation) },
             )
         }
         // Check if the front side is visible
-        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).assertExists()
+        composeTestRule.onNodeWithTag(FLIPPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).assertExists()
 
         // Check if the back side is not visible
-        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(FLIPPABLE_FLASHCARD_BACK_SIDE_TEST_TAG).assertDoesNotExist()
     }
 
     @Test
-    fun `Given flipableFlashcard When swipe right Then check back side is visible`() {
+    fun `Given flippableFlashcard When swipe right Then check back side is visible`() {
         composeTestRule.setContent {
-            FlipableFlashcard(
+            FlippableFlashcard(
                 front = { Text(text = word) },
                 back = { Text(text = translation) },
             )
         }
 
         // Flip the card with a swipe right gesture
-        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).performTouchInput { swipeRight() }
+        composeTestRule.onNodeWithTag(FLIPPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).performTouchInput { swipeRight() }
         // Check if the back side of the flashcard is visible
-        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG).assertExists()
+        composeTestRule.onNodeWithTag(FLIPPABLE_FLASHCARD_BACK_SIDE_TEST_TAG).assertExists()
         // Check if the front side of the flashcard is not visible
-        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(FLIPPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).assertDoesNotExist()
     }
 
     @Test
-    fun `Given flipableFlashcard When swipe right and left Then check front side is visible`() {
+    fun `Given flippableFlashcard When swipe right and left Then check front side is visible`() {
         composeTestRule.setContent {
-            FlipableFlashcard(
+            FlippableFlashcard(
                 front = { Text(text = word) },
                 back = { Text(text = translation) },
             )
         }
 
         // Flip the card with a swipe right gesture
-        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).performTouchInput { swipeRight() }
+        composeTestRule.onNodeWithTag(FLIPPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).performTouchInput { swipeRight() }
 
         // Flip the card with a swipe to left gesture to bring it back to the initial state
-        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG).performTouchInput { swipeLeft() }
+        composeTestRule.onNodeWithTag(FLIPPABLE_FLASHCARD_BACK_SIDE_TEST_TAG).performTouchInput { swipeLeft() }
 
         // Check if the front side of the flashcard is visible
-        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).assertExists()
+        composeTestRule.onNodeWithTag(FLIPPABLE_FLASHCARD_FRONT_SIDE_TEST_TAG).assertExists()
         // Check if the back side of the flashcard is not visible
-        composeTestRule.onNodeWithTag(FLIPABLE_FLASHCARD_BACK_SIDE_TEST_TAG).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(FLIPPABLE_FLASHCARD_BACK_SIDE_TEST_TAG).assertDoesNotExist()
     }
 }


### PR DESCRIPTION
- Created `FlipableFlashcard` composable to display a card with front and back content.
- Implemented horizontal swipe gestures to flip between the front and back of the card.
- Used `animateFloatAsState` for smooth rotation animation.
- Used `detectHorizontalDragGestures` to enable the flip gesture.
- Added a preview for `FlipableFlashcard` for demonstration purposes.