### PR TITLE
Implement Local Storage of User Word Reactions

### DIFF
--- a/data/local/src/androidTest/java/com/epiclabs/thinktok/data/local/dao/WordReactionDaoTestImpl.kt
+++ b/data/local/src/androidTest/java/com/epiclabs/thinktok/data/local/dao/WordReactionDaoTestImpl.kt
@@ -1,0 +1,98 @@
+package com.epiclabs.thinktok.data.local.dao
+
+import com.epiclabs.thinktok.data.local.mapper.toWordEntity
+import com.epiclabs.thinktok.data.local.mapper.toWordReaction
+import com.epiclabs.thinktok.data.local.mapper.toWordReactionEntity
+import com.epiclabs.thinktok.main.domain.api.model.Word
+import com.epiclabs.thinktok.main.domain.api.model.WordReaction
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+internal class WordReactionDaoTestImpl : WordDatabaseTest() {
+    private lateinit var wordReactionDao: WordReactionDao
+    private lateinit var wordDao: WordDao
+
+    @Before
+    fun initDao() {
+        wordDao = db.wordDao()
+        wordReactionDao = db.wordReactionDao()
+    }
+
+    @Test
+    fun insertAndGetWordReaction_shouldRetrieveCorrectReaction() =
+        runTest {
+            // Given
+            val initialWord =
+                Word(
+                    id = 1,
+                    word = "word",
+                    translation = "translation",
+                )
+
+            val initialWordReaction =
+                WordReaction(
+                    id = 1,
+                    wordId = 1,
+                    reaction = true,
+                    timestamp = 123456789,
+                )
+
+            // When
+            /*
+             * As word_reactions table is a one to one relationship with words table, we need to insert word first.
+             * */
+            db.wordDao().insertAll(listOf(initialWord.toWordEntity()))
+            wordReactionDao.insert(initialWordReaction.toWordReactionEntity())
+
+            // Then
+            val retrievedWordReaction =
+                wordReactionDao
+                    .getWordReaction(wordId = initialWordReaction.id)
+                    .firstOrNull()
+                    ?.firstOrNull()
+                    ?.toWordReaction()
+            assertEquals(initialWordReaction, retrievedWordReaction)
+        }
+
+    @Test
+    fun clearWordReaction_shouldRetrieveEmptyList() =
+        runTest {
+            // Given
+            val word =
+                Word(
+                    id = 1,
+                    word = "word",
+                    translation = "translation",
+                )
+
+            val wordReaction =
+                WordReaction(
+                    id = 1,
+                    wordId = 1,
+                    reaction = true,
+                    timestamp = 123456789,
+                )
+
+            // When
+        /*
+         * As word_reactions table is a one to one relationship with words table, we need to insert word first.
+         * */
+            db.wordDao().insertAll(listOf(word.toWordEntity()))
+            wordReactionDao.insert(wordReaction.toWordReactionEntity())
+
+            // Then
+            wordReactionDao.clearAll()
+            val retrievedWordReaction =
+                wordReactionDao
+                    .getWordReaction(wordId = wordReaction.id)
+                    .firstOrNull()
+                    ?.map {
+                        it.toWordReaction()
+                    }
+
+            assertEquals(emptyList<WordReaction>(), retrievedWordReaction)
+        }
+}

--- a/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/dao/WordReactionDao.kt
+++ b/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/dao/WordReactionDao.kt
@@ -1,0 +1,16 @@
+package com.epiclabs.thinktok.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.epiclabs.thinktok.data.local.entity.WordReactionEntity
+
+@Dao
+internal interface WordReactionDao {
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(wordReaction: WordReactionEntity)
+
+    @Query("SELECT * FROM word_reactions WHERE word_id = :wordId")
+    suspend fun getWordReaction(wordId: Int): List<WordReactionEntity>?
+}

--- a/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/dao/WordReactionDao.kt
+++ b/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/dao/WordReactionDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.epiclabs.thinktok.data.local.entity.WordReactionEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 internal interface WordReactionDao {
@@ -12,5 +13,8 @@ internal interface WordReactionDao {
     suspend fun insert(wordReaction: WordReactionEntity)
 
     @Query("SELECT * FROM word_reactions WHERE word_id = :wordId")
-    suspend fun getWordReaction(wordId: Int): List<WordReactionEntity>?
+    fun getWordReaction(wordId: Int): Flow<List<WordReactionEntity>>
+
+    @Query("DELETE FROM word_reactions")
+    suspend fun clearAll()
 }

--- a/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/db/AppDatabase.kt
+++ b/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/db/AppDatabase.kt
@@ -4,13 +4,16 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.epiclabs.thinktok.data.local.dao.UserPreferenceDao
 import com.epiclabs.thinktok.data.local.dao.WordDao
+import com.epiclabs.thinktok.data.local.dao.WordReactionDao
 import com.epiclabs.thinktok.data.local.entity.UserPreferenceEntity
 import com.epiclabs.thinktok.data.local.entity.WordEntity
+import com.epiclabs.thinktok.data.local.entity.WordReactionEntity
 
 @Database(
     entities = [
         UserPreferenceEntity::class,
         WordEntity::class,
+        WordReactionEntity::class,
     ],
     version = 1,
     exportSchema = false,
@@ -19,4 +22,6 @@ internal abstract class AppDatabase : RoomDatabase() {
     abstract fun userPreferenceDao(): UserPreferenceDao
 
     abstract fun wordDao(): WordDao
+
+    abstract fun wordReactionDao(): WordReactionDao
 }

--- a/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/di/dataModule.kt
+++ b/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/di/dataModule.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.room.Room
 import com.epiclabs.thinktok.data.local.dao.UserPreferenceDao
 import com.epiclabs.thinktok.data.local.dao.WordDao
+import com.epiclabs.thinktok.data.local.dao.WordReactionDao
 import com.epiclabs.thinktok.data.local.db.AppDatabase
 import com.epiclabs.thinktok.data.local.source.UserPreferenceLocalDataSourceImpl
 import com.epiclabs.thinktok.data.local.source.WordLocalDataSourceImpl
@@ -16,9 +17,10 @@ val dataModule =
         single { provideDatabase(get()) }
         single { provideUserPreferenceDao(get()) }
         single { provideWordDao(get()) }
+        single { provideWordReactionDao(get()) }
 
         single<UserPreferenceLocalDataSource> { UserPreferenceLocalDataSourceImpl(get()) }
-        single<WordLocalDataSource> { WordLocalDataSourceImpl(get()) }
+        single<WordLocalDataSource> { WordLocalDataSourceImpl(get(), get()) }
     }
 
 private fun provideDatabase(application: Application): AppDatabase {
@@ -35,4 +37,8 @@ private fun provideUserPreferenceDao(database: AppDatabase): UserPreferenceDao {
 
 private fun provideWordDao(database: AppDatabase): WordDao {
     return database.wordDao()
+}
+
+private fun provideWordReactionDao(database: AppDatabase): WordReactionDao {
+    return database.wordReactionDao()
 }

--- a/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/entity/WordReactionEntity.kt
+++ b/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/entity/WordReactionEntity.kt
@@ -1,0 +1,26 @@
+package com.epiclabs.thinktok.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "word_reactions",
+    foreignKeys = [
+        ForeignKey(
+            entity = WordEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["word_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index(value = ["word_id"], unique = true)],
+)
+internal data class WordReactionEntity(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    @ColumnInfo(name = "word_id") val wordId: Int,
+    @ColumnInfo(name = "reaction") val reaction: Boolean, // true for "know", false for "don't know"
+    @ColumnInfo(name = "timestamp") val timestamp: Long,
+)

--- a/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/mapper/WordReactionMapper.kt
+++ b/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/mapper/WordReactionMapper.kt
@@ -1,0 +1,22 @@
+package com.epiclabs.thinktok.data.local.mapper
+
+import com.epiclabs.thinktok.data.local.entity.WordReactionEntity
+import com.epiclabs.thinktok.main.domain.api.model.WordReaction
+
+internal fun WordReactionEntity.toWordReaction(): WordReaction {
+    return WordReaction(
+        id = this.id,
+        wordId = this.wordId,
+        reaction = this.reaction,
+        timestamp = this.timestamp,
+    )
+}
+
+internal fun WordReaction.toWordReactionEntity(): WordReactionEntity {
+    return WordReactionEntity(
+        id = this.id,
+        wordId = this.wordId,
+        reaction = this.reaction,
+        timestamp = this.timestamp,
+    )
+}

--- a/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/source/WordLocalDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/com/epiclabs/thinktok/data/local/source/WordLocalDataSourceImpl.kt
@@ -12,9 +12,14 @@ import com.epiclabs.thinktok.main.domain.api.model.Word
 import com.epiclabs.thinktok.main.repository.api.WordLocalDataSource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import com.epiclabs.thinktok.data.local.dao.WordReactionDao
+import com.epiclabs.thinktok.data.local.mapper.toWordReaction
+import com.epiclabs.thinktok.data.local.mapper.toWordReactionEntity
+import com.epiclabs.thinktok.main.domain.api.model.WordReaction
 
 internal class WordLocalDataSourceImpl(
     private val wordDao: WordDao,
+    private val wordReactionDao: WordReactionDao,
 ) : WordLocalDataSource {
     override fun getWords(): Flow<PagingData<Word>> {
         return Pager(
@@ -38,5 +43,22 @@ internal class WordLocalDataSourceImpl(
 
     override suspend fun clearAllWords() {
         wordDao.clearAll()
+    }
+
+    override suspend fun getWordReactions(wordId: Int): Flow<List<WordReaction>> =
+        wordReactionDao
+            .getWordReaction(wordId)
+            .map {
+                it.map { wordReactionEntity ->
+                    wordReactionEntity.toWordReaction()
+                }
+            }
+
+    override suspend fun insertWordReaction(wordReaction: WordReaction) {
+        wordReactionDao.insert(wordReaction.toWordReactionEntity())
+    }
+
+    override suspend fun clearAllWordReactions() {
+        wordReactionDao.clearAll()
     }
 }

--- a/feature/main/domain/api/src/main/kotlin/com/epiclabs/thinktok/main/domain/api/model/WordReaction.kt
+++ b/feature/main/domain/api/src/main/kotlin/com/epiclabs/thinktok/main/domain/api/model/WordReaction.kt
@@ -1,0 +1,8 @@
+package com.epiclabs.thinktok.main.domain.api.model
+
+data class WordReaction(
+    val id: Int,
+    val wordId: Int,
+    val reaction: Boolean,
+    val timestamp: Long,
+)

--- a/feature/main/domain/api/src/main/kotlin/com/epiclabs/thinktok/main/domain/api/repository/WordRepository.kt
+++ b/feature/main/domain/api/src/main/kotlin/com/epiclabs/thinktok/main/domain/api/repository/WordRepository.kt
@@ -2,12 +2,17 @@ package com.epiclabs.thinktok.main.domain.api.repository
 
 import androidx.paging.PagingData
 import com.epiclabs.thinktok.main.domain.api.model.Word
+import com.epiclabs.thinktok.main.domain.api.model.WordReaction
 import kotlinx.coroutines.flow.Flow
 
 interface WordRepository {
+    fun getWords(): Flow<PagingData<Word>>
+
     suspend fun insertWords(words: List<Word>)
 
     suspend fun clearAllWords()
 
-    fun getWords(): Flow<PagingData<Word>>
+    suspend fun insertWordReaction(wordReaction: WordReaction)
+
+    suspend fun clearAllWordReactions()
 }

--- a/feature/main/domain/src/main/kotlin/com/epiclabs/thinktok/main/domain/InsertWordReactionUseCase.kt
+++ b/feature/main/domain/src/main/kotlin/com/epiclabs/thinktok/main/domain/InsertWordReactionUseCase.kt
@@ -1,0 +1,10 @@
+package com.epiclabs.thinktok.main.domain
+
+import com.epiclabs.thinktok.main.domain.api.model.WordReaction
+import com.epiclabs.thinktok.main.domain.api.repository.WordRepository
+
+class InsertWordReactionUseCase(
+    private val repository: WordRepository,
+) {
+    suspend operator fun invoke(wordReaction: WordReaction) = repository.insertWordReaction(wordReaction)
+}

--- a/feature/main/domain/src/main/kotlin/com/epiclabs/thinktok/main/domain/di/MainDomainModule.kt
+++ b/feature/main/domain/src/main/kotlin/com/epiclabs/thinktok/main/domain/di/MainDomainModule.kt
@@ -7,6 +7,7 @@ import org.koin.dsl.module
 import com.epiclabs.thinktok.core.ioDispatcherQualifier
 import com.epiclabs.thinktok.main.domain.GetLanguageScreenStringResourcesUseCase
 import com.epiclabs.thinktok.main.domain.GetWordsUseCase
+import com.epiclabs.thinktok.main.domain.InsertWordReactionUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 
 val mainDomainModule =
@@ -25,5 +26,8 @@ val mainDomainModule =
         }
         factory {
             GetWordsUseCase(get())
+        }
+        factory {
+            InsertWordReactionUseCase(get())
         }
     }

--- a/feature/main/repository/api/src/main/kotlin/com/epiclabs/thinktok/main/repository/api/WordLocalDataSource.kt
+++ b/feature/main/repository/api/src/main/kotlin/com/epiclabs/thinktok/main/repository/api/WordLocalDataSource.kt
@@ -2,6 +2,7 @@ package com.epiclabs.thinktok.main.repository.api
 
 import androidx.paging.PagingData
 import com.epiclabs.thinktok.main.domain.api.model.Word
+import com.epiclabs.thinktok.main.domain.api.model.WordReaction
 import kotlinx.coroutines.flow.Flow
 
 interface WordLocalDataSource {
@@ -10,4 +11,10 @@ interface WordLocalDataSource {
     suspend fun insertWords(words: List<Word>)
 
     suspend fun clearAllWords()
+
+    suspend fun getWordReactions(wordId: Int): Flow<List<WordReaction>>
+
+    suspend fun insertWordReaction(wordReaction: WordReaction)
+
+    suspend fun clearAllWordReactions()
 }

--- a/feature/main/repository/src/main/kotlin/com/epiclabs/thinktok/main/repository/WordRepositoryImpl.kt
+++ b/feature/main/repository/src/main/kotlin/com/epiclabs/thinktok/main/repository/WordRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.epiclabs.thinktok.main.repository
 
 import androidx.paging.PagingData
 import com.epiclabs.thinktok.main.domain.api.model.Word
+import com.epiclabs.thinktok.main.domain.api.model.WordReaction
 import com.epiclabs.thinktok.main.domain.api.repository.WordRepository
 import com.epiclabs.thinktok.main.repository.api.WordLocalDataSource
 import kotlinx.coroutines.CoroutineDispatcher
@@ -28,4 +29,16 @@ internal class WordRepositoryImpl(
         withContext(ioDispatcher) {
             wordLocalDataSource.clearAllWords()
         }
+
+    override suspend fun insertWordReaction(wordReaction: WordReaction) {
+        withContext(ioDispatcher) {
+            wordLocalDataSource.insertWordReaction(wordReaction)
+        }
+    }
+
+    override suspend fun clearAllWordReactions() {
+        withContext(ioDispatcher) {
+            wordLocalDataSource.clearAllWordReactions()
+        }
+    }
 }


### PR DESCRIPTION
**Changes:**

-   Created a `word_reactions` table in the local database.
-   Added `WordReaction` entity to represent a user's reaction to a word.
-   Implemented `WordReactionDao` for database interactions.
-   Added logic to save user reactions (word ID, reaction, timestamp) to the database.
-   Ensured that only one reaction per word is saved.
- Added tests for `WordReactionDao`.

**Testing:**

-   Added unit tests for `WordReactionDao` to verify correct database interactions.

**Related Issue:**

-   https://github.com/epic-labs-org/ThinkTokAndroid/issues/17